### PR TITLE
Add auth lock utility and wrap Supabase auth calls

### DIFF
--- a/src/components/AuthRedirectMiddleware.jsx
+++ b/src/components/AuthRedirectMiddleware.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { supabase } from '../lib/supabase';
+import { withAuthLock } from '../lib/authLock.js';
 import toast from 'react-hot-toast';
 
 const AuthRedirectMiddleware = () => {
@@ -30,7 +31,7 @@ const AuthRedirectMiddleware = () => {
           setIsProcessing(true);
           
           // Timeout aumentado para evitar cuelgues
-          const sessionPromise = supabase.auth.getSession();
+          const sessionPromise = withAuthLock(() => supabase.auth.getSession());
           const timeoutPromise = new Promise((_, reject) => {
             setTimeout(() => reject(new Error('Session timeout')), 15000);
           });
@@ -102,10 +103,12 @@ const AuthRedirectMiddleware = () => {
           }
           
           // Establecer la sesión con los tokens explícitamente
-          const { data, error } = await supabase.auth.setSession({
-            access_token: accessToken,
-            refresh_token: refreshToken
-          });
+          const { data, error } = await withAuthLock(() =>
+            supabase.auth.setSession({
+              access_token: accessToken,
+              refresh_token: refreshToken
+            })
+          );
           
           if (error) {
             throw error;

--- a/src/components/DebugInfo.jsx
+++ b/src/components/DebugInfo.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, memo, useCallback } from 'react';
 import { supabase } from '../lib/supabase';
+import { withAuthLock } from '../lib/authLock.js';
 import { useAuth } from '../context/AuthContext';
 
 const DebugInfo = memo(({ alwaysVisible = false }) => {
@@ -23,7 +24,7 @@ const DebugInfo = memo(({ alwaysVisible = false }) => {
 
   const checkAuthStatus = useCallback(async () => {
     try {
-      const { data, error } = await supabase.auth.getSession();
+      const { data, error } = await withAuthLock(() => supabase.auth.getSession());
       if (error) return `Error: ${error.message}`;
       return data.session ? `Autenticado como ${data.session.user.email}` : 'No autenticado';
     } catch (err) {

--- a/src/lib/authLock.js
+++ b/src/lib/authLock.js
@@ -1,0 +1,6 @@
+let last = Promise.resolve();
+export const withAuthLock = (fn) => {
+  const run = last.finally(() => fn());
+  last = run.catch(() => {});
+  return run;
+};

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js';
+import { withAuthLock } from './authLock.js';
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
@@ -126,7 +127,7 @@ export const getCurrentUser = async () => {
     
     // Operación con timeout y reintentos
     const sessionOperation = async () => {
-      const { data: { session }, error: sessionError } = await supabase.auth.getSession();
+      const { data: { session }, error: sessionError } = await withAuthLock(() => supabase.auth.getSession());
       
       if (sessionError) {
         console.error('Error al obtener la sesión:', sessionError);
@@ -245,7 +246,7 @@ export const getCurrentUser = async () => {
       console.log('Timeout detectado, limpiando estado...');
       try {
         // Intentar refrescar la sesión
-        await supabase.auth.refreshSession();
+        await withAuthLock(() => supabase.auth.refreshSession());
       } catch (refreshError) {
         console.error('Error al refrescar sesión:', refreshError);
       }
@@ -257,7 +258,7 @@ export const getCurrentUser = async () => {
 
 export const signOut = async () => {
   try {
-    const { error } = await supabase.auth.signOut();
+    const { error } = await withAuthLock(() => supabase.auth.signOut());
     if (error) throw error;
     
     // Clear all local storage

--- a/src/pages/AdminPage.jsx
+++ b/src/pages/AdminPage.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { supabase } from '../lib/supabase';
+import { withAuthLock } from '../lib/authLock.js';
 import { Users, Code, Shield, Key, Bug } from 'lucide-react';
 import DebugInfo from '../components/DebugInfo';
 import toast from 'react-hot-toast';
@@ -27,7 +28,7 @@ const AdminPage = () => {
   }, [activeTab]);
 
   const checkAdminAccess = async () => {
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: { user } } = await withAuthLock(() => supabase.auth.getUser());
     
     if (!user) {
       navigate('/login');

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { supabase } from '../lib/supabase';
+import { withAuthLock } from '../lib/authLock.js';
 import { Code, Save, Share2, Star, Bot, Heart } from 'lucide-react';
 import SyntaxHighlighter from 'react-syntax-highlighter';
 import { atomOneDark } from 'react-syntax-highlighter/dist/esm/styles/hljs';
@@ -13,7 +14,7 @@ const HomePage = () => {
   // Manejar redirecciones de autenticación
   useEffect(() => {
     const handleAuthRedirect = async () => {
-      const { data: { session } } = await supabase.auth.getSession();
+      const { data: { session } } = await withAuthLock(() => supabase.auth.getSession());
       const params = new URLSearchParams(location.search);
       const isRecovery = params.get('type') === 'recovery';
 

--- a/src/pages/ResetPasswordPage.jsx
+++ b/src/pages/ResetPasswordPage.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { supabase } from '../lib/supabase';
+import { withAuthLock } from '../lib/authLock.js';
 import { KeyRound, ArrowLeft } from 'lucide-react';
 import toast from 'react-hot-toast';
 
@@ -23,9 +24,11 @@ function ResetPasswordPage() {
       console.log('URL de redirección:', redirectUrl);
       console.log('Enviando correo a:', email);
       
-      const { error } = await supabase.auth.resetPasswordForEmail(email, {
-        redirectTo: redirectUrl,
-      });
+      const { error } = await withAuthLock(() =>
+        supabase.auth.resetPasswordForEmail(email, {
+          redirectTo: redirectUrl,
+        })
+      );
       
       if (error) {
         console.error('Error de Supabase al resetear contraseña:', error);

--- a/src/pages/SearchPage.jsx
+++ b/src/pages/SearchPage.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { supabase } from '../lib/supabase';
+import { withAuthLock } from '../lib/authLock.js';
 import CodeCard from '../components/CodeCard';
 import { Search as SearchIcon } from 'lucide-react';
 
@@ -16,7 +17,7 @@ const SearchPage = () => {
   }, []);
 
   const fetchUserFavorites = async () => {
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: { user } } = await withAuthLock(() => supabase.auth.getUser());
     
     if (user) {
       const { data, error } = await supabase
@@ -67,7 +68,7 @@ const SearchPage = () => {
   };
 
   const handleToggleFavorite = async (snippetId) => {
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: { user } } = await withAuthLock(() => supabase.auth.getUser());
     
     if (!user) {
       // Redirect to login or show a message

--- a/src/pages/SignupPage.jsx
+++ b/src/pages/SignupPage.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { supabase } from '../lib/supabase';
+import { withAuthLock } from '../lib/authLock.js';
 import { UserPlus } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { useAuth } from '../context/AuthContext';
@@ -32,13 +33,15 @@ function SignupPage() {
       }
 
       // Crear usuario de autenticación
-      const { data: authData, error: signUpError } = await supabase.auth.signUp({
-        email,
-        password,
-        options: {
-          data: { username }
-        }
-      });
+      const { data: authData, error: signUpError } = await withAuthLock(() =>
+        supabase.auth.signUp({
+          email,
+          password,
+          options: {
+            data: { username }
+          }
+        })
+      );
 
       if (signUpError) throw signUpError;
 

--- a/src/pages/UpdatePasswordPage.jsx
+++ b/src/pages/UpdatePasswordPage.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { supabase } from '../lib/supabase';
+import { withAuthLock } from '../lib/authLock.js';
 import { KeyRound } from 'lucide-react';
 import toast from 'react-hot-toast';
 
@@ -15,7 +16,7 @@ const UpdatePasswordPage = () => {
   useEffect(() => {
     const checkSessionAndUpdate = async () => {
       try {
-        const { data: { session }, error } = await supabase.auth.getSession();
+        const { data: { session }, error } = await withAuthLock(() => supabase.auth.getSession());
         
         if (error) {
           throw error;
@@ -76,7 +77,7 @@ const UpdatePasswordPage = () => {
 
     try {
       // Verificar sesión activa
-      const { data: { session }, error: sessionError } = await supabase.auth.getSession();
+      const { data: { session }, error: sessionError } = await withAuthLock(() => supabase.auth.getSession());
       
       if (sessionError) {
         throw sessionError;
@@ -110,7 +111,7 @@ const UpdatePasswordPage = () => {
       toast.success('Contraseña actualizada correctamente', { duration: 5000 });
       
       // Cerrar sesión de manera segura
-      await supabase.auth.signOut();
+      await withAuthLock(() => supabase.auth.signOut());
       window.localStorage.clear();
       
       // Mostrar mensaje y redirigir


### PR DESCRIPTION
## Summary
- implement `withAuthLock` helper to serialise auth requests
- wrap Supabase auth operations with the new lock
- apply lock in pages and components using Supabase auth

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68509df29f448321aadc956b9efd341f